### PR TITLE
Output edi

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,3 @@ See the [examples directory](https://github.com/sezna/edi/tree/master/examples) 
 * Only supports standard X12 EDI
 
 
-# Roadmap
-  * benches to identify regressions
-  * output back into EDI with proper padding in the ISA segment
-  * iterator over segments for the frequent cases in which there's only one transaction/functional group/interchange (EdiDocument.segments_iter() -> SegmentIter?)
-    * to_string(delimiters) is needed to output the edi document

--- a/src/edi_document.rs
+++ b/src/edi_document.rs
@@ -21,6 +21,27 @@ pub struct EdiDocument<'a, 'b> {
     pub element_delimiter: char,
 }
 
+impl EdiDocument<'_, '_> {
+    /// Turns this [EdiDocument] into an ANSI x12 string.
+    pub fn to_x12_string(&self) -> String {
+        let mut buffer = String::new();
+        let mut idx = 0;
+        for interchange in self.interchanges.iter() {
+            if idx > 0 {
+                buffer.push(self.segment_delimiter);
+            }
+            buffer.push_str(&interchange.to_x12_string(
+                self.segment_delimiter,
+                self.element_delimiter,
+                self.sub_element_delimiter,
+            ));
+            idx += 1;
+        }
+
+        buffer
+    }
+}
+
 /// This is the main entry point to the crate. Parse an input str and output either
 /// an [EdiParseError] or a resulting [EdiDocument].
 pub fn parse(input: &str) -> Result<EdiDocument, EdiParseError> {

--- a/src/edi_document.rs
+++ b/src/edi_document.rs
@@ -13,6 +13,12 @@ pub struct EdiDocument<'a, 'b> {
     /// Represents the interchanges (ISA/IEA) held within this document.
     #[serde(borrow = "'a + 'b")]
     pub interchanges: VecDeque<InterchangeControl<'a, 'b>>,
+    /// Represents the separator between segments in the EDI document.
+    pub segment_delimiter: char,
+    /// Represents the separator between sub elements in the EDI document.
+    pub sub_element_delimiter: char,
+    /// Represents the separator between elements in the EDI document.
+    pub element_delimiter: char,
 }
 
 /// This is the main entry point to the crate. Parse an input str and output either
@@ -30,7 +36,8 @@ pub fn loose_parse(input: &str) -> Result<EdiDocument, EdiParseError> {
 
 /// An internal function which is the root of the parsing. It is accessed publicly via [parse] and [loose_parse].
 fn parse_inner(input: &str, loose: bool) -> Result<EdiDocument, EdiParseError> {
-    let document_tokens = tokenize(input)?;
+    let tokenize_result = tokenize(input)?;
+    let document_tokens = tokenize_result.tokens;
 
     // Go through all the segments and parse them either into an interchange control header,
     // functional group header, transaction header, or generic segment. Also verify that
@@ -71,5 +78,10 @@ fn parse_inner(input: &str, loose: bool) -> Result<EdiDocument, EdiParseError> {
         }
     }
 
-    return Ok(EdiDocument { interchanges });
+    return Ok(EdiDocument {
+        interchanges,
+        element_delimiter: tokenize_result.element_delimiter,
+        sub_element_delimiter: tokenize_result.sub_element_delimiter,
+        segment_delimiter: tokenize_result.segment_delimiter,
+    });
 }

--- a/src/functional_group.rs
+++ b/src/functional_group.rs
@@ -172,7 +172,7 @@ impl<'a, 'b> FunctionalGroup<'a, 'b> {
 
     /// Converts this functional group into an ANSI x12 string for use in an EDI document.
     pub fn to_x12_string(&self, segment_delimiter: char, element_delimiter: char) -> String {
-        let mut header = String::from("GS");
+        let header = String::from("GS");
         let elements_of_gs = vec![
             self.functional_identifier_code.clone(),
             self.application_sender_code.clone(),
@@ -200,6 +200,14 @@ impl<'a, 'b> FunctionalGroup<'a, 'b> {
 
         buffer.push_str(&transactions);
 
+        let mut closer = String::from("GE");
+        closer.push(element_delimiter);
+        closer.push_str(&self.transactions.len().to_string());
+        closer.push(element_delimiter);
+        closer.push_str(&self.group_control_number);
+
+        buffer.push(segment_delimiter);
+        buffer.push_str(&closer);
         buffer
     }
 }
@@ -246,7 +254,7 @@ fn functional_group_to_string() {
         version: Cow::from("004010"),
         transactions: VecDeque::from_iter(vec![transaction].into_iter()),
     };
-    assert_eq!(functional_group.to_x12_string('~', '>'), "");
+    assert_eq!(functional_group.to_x12_string('\n', '*'), "GS*PO*SENDERGS*007326879*20020226*1534*1*X*004010\nST*140*100000001*\nBGN*20*TEST_ID*200615*0000\nBGN*15*OTHER_TEST_ID***END\nSE*4*100000001\nGE*1*1");
 }
 
 #[test]

--- a/src/generic_segment.rs
+++ b/src/generic_segment.rs
@@ -40,6 +40,31 @@ impl<'a> GenericSegment<'a> {
             elements,
         })
     }
+
+    /// Converts a single generic segment into an ANSI x12 compliant string to be used in an EDI
+    /// document.
+    pub fn to_x12_string(&self, element_delimiter: char) -> String {
+        self.elements
+            .iter()
+            .fold(self.segment_abbreviation.to_string(), |mut acc, s| {
+                acc.push(element_delimiter);
+                acc.push_str(s);
+                acc
+            })
+    }
+}
+
+#[test]
+fn convert_generic_segment_to_string() {
+    let segment = GenericSegment {
+        segment_abbreviation: Cow::from("BGN"),
+        elements: vec!["20", "TEST_ID", "200615", "0000"]
+            .iter()
+            .map(|x| Cow::from(*x))
+            .collect::<VecDeque<Cow<str>>>(),
+    };
+
+    assert_eq!(segment.to_x12_string('*'), "BGN*20*TEST_ID*200615*0000");
 }
 
 #[test]

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -113,7 +113,7 @@ impl<'a, 'b> Transaction<'a, 'b> {
             str::parse::<usize>(tokens[1]).unwrap() == self.segments.len() + 2,
             "transaction validation failed: incorrect number of segments",
             tokens[1],
-            self.segments.len(),
+            self.segments.len() + 2,
             tokens
         );
         edi_assert!(
@@ -149,7 +149,7 @@ impl<'a, 'b> Transaction<'a, 'b> {
 
         let mut closer = "SE".to_string();
         closer.push(element_delimiter);
-        closer.push_str(&self.segments.len().to_string());
+        closer.push_str(&(self.segments.len() + 2).to_string()); // +2 because the count includes the ST and SE segments
         closer.push(element_delimiter);
         closer.push_str(&self.transaction_set_control_number.clone());
 
@@ -192,7 +192,7 @@ fn transaction_to_string() {
 
     assert_eq!(
         transaction.to_x12_string('~', '*'),
-        "ST*140*100000001*~BGN*20*TEST_ID*200615*0000~BGN*15*OTHER_TEST_ID***END~SE*2*100000001"
+        "ST*140*100000001*~BGN*20*TEST_ID*200615*0000~BGN*15*OTHER_TEST_ID***END~SE*4*100000001"
     );
 }
 


### PR DESCRIPTION
Added the `.to_x12_string()` method to `EdiDocument`, which renders it to a valid ANSI x12 EDI string. Full round tripping was tested. 