### PR TITLE
transaction_name to Cow for serialization

### DIFF
--- a/src/edi_document.rs
+++ b/src/edi_document.rs
@@ -7,12 +7,12 @@ use std::collections::VecDeque;
 /// Represents an entire parsed EDI document with both the envelope (i.e. metadata) and
 /// the data segments.
 #[derive(Serialize, Deserialize)]
-pub struct EdiDocument<'a, 'b> {
+pub struct EdiDocument<'a> {
     // Here I chose a VecDeque because when I output an EDI document, I want to pull from
     // it in a queue style.
     /// Represents the interchanges (ISA/IEA) held within this document.
-    #[serde(borrow = "'a + 'b")]
-    pub interchanges: VecDeque<InterchangeControl<'a, 'b>>,
+    #[serde(borrow = "'a")]
+    pub interchanges: VecDeque<InterchangeControl<'a>>,
     /// Represents the separator between segments in the EDI document.
     pub segment_delimiter: char,
     /// Represents the separator between sub elements in the EDI document.
@@ -21,7 +21,7 @@ pub struct EdiDocument<'a, 'b> {
     pub element_delimiter: char,
 }
 
-impl EdiDocument<'_, '_> {
+impl EdiDocument<'_> {
     /// Turns this [EdiDocument] into an ANSI x12 string.
     pub fn to_x12_string(&self) -> String {
         let mut buffer = String::new();

--- a/src/functional_group.rs
+++ b/src/functional_group.rs
@@ -10,7 +10,7 @@ use std::collections::VecDeque;
 /// Represents a GS/GE segment which wraps a functional group.
 /// Documentation here gleaned mostly from [here](http://u.sezna.dev/b)
 #[derive(PartialEq, Debug, Serialize, Deserialize)]
-pub struct FunctionalGroup<'a, 'b> {
+pub struct FunctionalGroup<'a> {
     /// Identifies the function of this group.
     /// See http://ecomgx17.ecomtoday.com/edi/EDI_4010/el479.htm for a list of
     /// functional identifier codes.
@@ -48,15 +48,15 @@ pub struct FunctionalGroup<'a, 'b> {
     #[serde(borrow)]
     pub version: Cow<'a, str>,
     /// The transactions that this functional group contains.
-    #[serde(borrow = "'a + 'b")]
-    pub transactions: VecDeque<Transaction<'a, 'b>>,
+    #[serde(borrow = "'a")]
+    pub transactions: VecDeque<Transaction<'a>>,
 }
 
-impl<'a, 'b> FunctionalGroup<'a, 'b> {
+impl<'a, 'b> FunctionalGroup<'a> {
     /// Given [SegmentTokens](struct.SegmentTokens.html) (where the first token is "GS"), construct a [FunctionalGroup].
     pub(crate) fn parse_from_tokens(
         input: SegmentTokens<'a>,
-    ) -> Result<FunctionalGroup<'a, 'b>, EdiParseError> {
+    ) -> Result<FunctionalGroup<'a>, EdiParseError> {
         let elements: Vec<&str> = input.iter().map(|x| x.trim()).collect();
         // I always inject invariants wherever I can to ensure debugging is quick and painless,
         // and to check my assumptions.
@@ -237,7 +237,7 @@ fn functional_group_to_string() {
     );
     let transaction = Transaction {
         transaction_code: Cow::from("140"),
-        transaction_name: "",
+        transaction_name: Cow::from(""),
         transaction_set_control_number: Cow::from("100000001"),
         implementation_convention_reference: None,
         segments: segments,

--- a/src/interchange_control.rs
+++ b/src/interchange_control.rs
@@ -9,7 +9,7 @@ use std::collections::VecDeque;
 
 /// Represents the ISA/IEA header information commonly known as the "envelope" in X12 EDI.
 #[derive(PartialEq, Debug, Serialize, Deserialize)]
-pub struct InterchangeControl<'a, 'b> {
+pub struct InterchangeControl<'a> {
     // I chose to use `Cow`s here because I don't know how the crate will be used --
     // given enough documents of sufficient size and a restrictive enough environment,
     // the space complexity could undesirably grow. This allows for some mitigation
@@ -81,15 +81,15 @@ pub struct InterchangeControl<'a, 'b> {
     #[serde(borrow)]
     pub test_indicator: Cow<'a, str>, // P for production, T for test
     /// The [FunctionalGroups](struct.FunctionalGroup.html) contained in this interchange.
-    #[serde(borrow = "'a + 'b")]
-    pub functional_groups: VecDeque<FunctionalGroup<'a, 'b>>,
+    #[serde(borrow = "'a")]
+    pub functional_groups: VecDeque<FunctionalGroup<'a>>,
 }
 
-impl<'a, 'b> InterchangeControl<'a, 'b> {
+impl<'a> InterchangeControl<'a> {
     /// Given [SegmentTokens](struct.SegmentTokens.html) (where the first token is "ISA"), construct an [InterchangeControl].
     pub(crate) fn parse_from_tokens(
         input: SegmentTokens<'a>,
-    ) -> Result<InterchangeControl<'a, 'b>, EdiParseError> {
+    ) -> Result<InterchangeControl<'a>, EdiParseError> {
         let elements: Vec<&str> = input.iter().map(|x| x.trim()).collect();
         // I always inject invariants wherever I can to ensure debugging is quick and painless,
         // and to check my assumptions.
@@ -343,7 +343,7 @@ fn test_isa_to_string() {
     );
     let transaction = Transaction {
         transaction_code: Cow::from("140"),
-        transaction_name: "",
+        transaction_name: Cow::from(""),
         transaction_set_control_number: Cow::from("100000001"),
         implementation_convention_reference: None,
         segments: segments,

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -16,7 +16,7 @@ pub struct Transaction<'a> {
     pub transaction_code: Cow<'a, str>,
     /// The name of the transaction type in human-readable form.
     #[serde(borrow)]
-    pub transaction_name: Cow<'a, str>, // not a Cow because it is a reference to a HashMap value
+    pub transaction_name: Cow<'a, str>,
     /// Each transaction within a functional group also has a control number.
     /// Typically, trading partners use a number relative to the functional group in which they are contained.
     #[serde(borrow)]


### PR DESCRIPTION
I'm working on some python binding for this lib and was running into errors when trying to deserialize the equivalent python edi document object into an EdiDocument  with serde. 

`invalid type: string [...] expected a borrowed string`

Found a few other github issues related to serde and `&str`. [Example](https://github.com/serde-rs/serde/issues/1413#issuecomment-494892266). Any input would be appreciated. Everything seems to work just fine with a `Cow` instead of `&str`. Figured I'd submit the PR and see if you are open to merging upstream. Otherwise I will maintain a fork. 